### PR TITLE
Actually hide the enmity list if the user asks

### DIFF
--- a/EnmityPlugin/resources/enmity.js
+++ b/EnmityPlugin/resources/enmity.js
@@ -84,6 +84,11 @@ var enmity = new Vue({
       this.entries = e.detail.Enmity.Entries;
       this.target  = e.detail.Enmity.Target ? e.detail.Enmity.Target : noTarget;
       this.hide = (hideNoTarget && e.detail.Enmity.Target == null);
+      if(this.hide){
+        document.getElementById("enmity").style.visibility = "hidden";
+      }else{
+        document.getElementById("enmity").style.visibility = "visible";
+      }
     },
     updateState: function(e) {
       this.locked = e.detail.isLocked;


### PR DESCRIPTION
Without this change setting `var hideNoTarget = true;` does nothing.

With this change, the overlay is hidden whenever `hideNoTarget` is true, and nothing is targeted.